### PR TITLE
Avoid bytearray copy when guessing bytes input

### DIFF
--- a/filetype/utils.py
+++ b/filetype/utils.py
@@ -56,6 +56,6 @@ def get_bytes(obj):
         return get_signature_bytes(obj)
 
     if kind is bytes:
-        return signature(bytearray(obj))
+        return signature(obj)
 
     raise TypeError('Unsupported type as file input: %s' % kind)


### PR DESCRIPTION
This incurred a full copy, defeating the purpose of the signature
method.