### PR TITLE
support unicode path

### DIFF
--- a/filetype/utils.py
+++ b/filetype/utils.py
@@ -52,7 +52,7 @@ def get_bytes(obj):
     if kind is bytearray:
         return signature(obj)
 
-    if kind is str:
+    if kind is str or kind is unicode:
         return get_signature_bytes(obj)
 
     if kind is bytes:


### PR DESCRIPTION
while input `filepath` is unicode, it will raise `TypeError: Unsupported type as file input: <type 'unicode'>.`
This PR try to fix this issue