### PR TITLE
Include tests in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include README.rst
 include LICENSE
 include History.md
-include tests/
+graft tests/


### PR DESCRIPTION
Despite the line `include tests/`, there is currently no directory named tests in the PyPI tarball.