### PR TITLE
Reset reader position after retrieving signature bytes

### DIFF
--- a/filetype/utils.py
+++ b/filetype/utils.py
@@ -50,7 +50,10 @@ def get_bytes(obj):
         TypeError: if obj is not a supported type.
     """
     try:
-        obj = obj.read(_NUM_SIGNATURE_BYTES)
+        start_pos = obj.tell()
+        read_bytes = obj.read(_NUM_SIGNATURE_BYTES)
+        obj.seek(start_pos)
+        obj = read_bytes
     except AttributeError:
         # duck-typing as readable failed - we'll try the other options
         pass


### PR DESCRIPTION
Hi folks,

When using this library, we saw some unexpected behavior when using this library in-line with file uploads. We were passing the file pointer to `filetype.guess` directly, and then our handler would proceed to upload the file using the same file pointer. Since the pointer is not reset after `filetype.guess` runs, we were seeing truncated files. Wanted to raise this potential usage issue and offer this patch as a suggestion.

Otherwise, we've found this library to be super useful and easy to use, many thanks for your work on it.