### PR TITLE
Revert changes for webm and correct magic numbers for webp

### DIFF
--- a/filetype/types/image.py
+++ b/filetype/types/image.py
@@ -103,11 +103,17 @@ class Webp(Type):
         )
 
     def match(self, buf):
-        return (len(buf) > 11 and
+        return (len(buf) > 13 and
+                buf[0] == 0x52 and
+                buf[1] == 0x49 and
+                buf[2] == 0x46 and
+                buf[3] == 0x46 and
                 buf[8] == 0x57 and
                 buf[9] == 0x45 and
                 buf[10] == 0x42 and
-                buf[11] == 0x50)
+                buf[11] == 0x50 and
+                buf[12] == 0x56 and
+                buf[13] == 0x50)
 
 
 class Cr2(Type):

--- a/filetype/types/video.py
+++ b/filetype/types/video.py
@@ -94,22 +94,11 @@ class Webm(Type):
         )
 
     def match(self, buf):
-        return ((len(buf) > 3 and
+        return (len(buf) > 3 and
                 buf[0] == 0x1A and
                 buf[1] == 0x45 and
                 buf[2] == 0xDF and
-                buf[3] == 0xA3) or
-                (len(buf) > 13 and
-                    buf[0] == 0x52 and
-                    buf[1] == 0x49 and
-                    buf[2] == 0x46 and
-                    buf[3] == 0x46 and
-                    buf[8] == 0x57 and
-                    buf[9] == 0x45 and
-                    buf[10] == 0x42 and
-                    buf[11] == 0x50 and
-                    buf[12] == 0x56 and
-                    buf[13] == 0x50))
+                buf[3] == 0xA3)
 
 
 class Mov(IsoBmff):


### PR DESCRIPTION
The changes to webm was a mistake, and it should be patched to webp instead

The old magic number offset for webp detection is incorrect according to my inspection