### PR TITLE
Support special video/3gp file.

### DIFF
--- a/filetype/types/video.py
+++ b/filetype/types/video.py
@@ -24,6 +24,9 @@ class Mp4(IsoBmff):
             return False
 
         major_brand, minor_version, compatible_brands = self._get_ftyp(buf)
+        for brand in compatible_brands:
+            if brand in ['mp41', 'mp42', 'isom']:
+                return True
         return major_brand in ['mp41', 'mp42', 'isom']
 
 


### PR DESCRIPTION
A 3gp video made by Blackberry 8900, it has 'major_brand: 3gp4, minor_version: 256, compatible_brands: 3gp53gp4isom'.
Yes, the 'isom' in compatible_brands.
So, it should check compatible_brands also.