### PR TITLE
Add python 3.9 to version classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: System',
         'Topic :: System :: Filesystems',
         'Topic :: Utilities'],


### PR DESCRIPTION
Update setup.py metadata to include version python version classifiers that we already test against