### PR TITLE
Add support for all WOFF/WOFF2 flavors (Alternative to #118)

### DIFF
--- a/filetype/types/font.py
+++ b/filetype/types/font.py
@@ -19,15 +19,11 @@ class Woff(Type):
         )
 
     def match(self, buf):
-        return (len(buf) > 7 and
+        return (len(buf) > 3 and
                 buf[0] == 0x77 and
                 buf[1] == 0x4F and
                 buf[2] == 0x46 and
-                buf[3] == 0x46 and
-                buf[4] == 0x00 and
-                buf[5] == 0x01 and
-                buf[6] == 0x00 and
-                buf[7] == 0x00)
+                buf[3] == 0x46)
 
 
 class Woff2(Type):
@@ -44,15 +40,11 @@ class Woff2(Type):
         )
 
     def match(self, buf):
-        return (len(buf) > 7 and
+        return (len(buf) > 3 and
                 buf[0] == 0x77 and
                 buf[1] == 0x4F and
                 buf[2] == 0x46 and
-                buf[3] == 0x32 and
-                buf[4] == 0x00 and
-                buf[5] == 0x01 and
-                buf[6] == 0x00 and
-                buf[7] == 0x00)
+                buf[3] == 0x32)
 
 
 class Ttf(Type):


### PR DESCRIPTION
Hi, according to the [WOFF File Format 1.0](https://www.w3.org/TR/WOFF/#WOFFHeader) and [WOFF File Format 2.0](https://www.w3.org/TR/WOFF2/#woff20Header) specifications, 

> Although only fonts of type `0x00010000` [...] and `0x4F54544F` [...] are widely supported at present, it is not an error in the WOFF file if the flavor field contains a different value, indicating a WOFF-packaged version of a different sfnt flavor.

Thus I'm proposing to remove the check for the `0x00010000` flavor from the WOFF and WOFF2 matchers. This would ensure that files of other WOFF flavors (like the common one embedding CFF glyphs/OpenType) would be correctly identified by this library.

Alternatively, if allowing arbitrary flavors seems too loose to you., I also prepared a PR that allows the three most common flavors that are also mentioned in the format specification: https://github.com/h2non/filetype.py/pull/118