### PR TITLE
Add support for more WOFF/WOFF2 flavors (Alternative to #117)

### DIFF
--- a/filetype/types/font.py
+++ b/filetype/types/font.py
@@ -19,7 +19,7 @@ class Woff(Type):
         )
 
     def match(self, buf):
-        return (len(buf) > 3 and
+        return (len(buf) > 7 and
                 buf[0] == 0x77 and
                 buf[1] == 0x4F and
                 buf[2] == 0x46 and

--- a/filetype/types/font.py
+++ b/filetype/types/font.py
@@ -19,15 +19,23 @@ class Woff(Type):
         )
 
     def match(self, buf):
-        return (len(buf) > 7 and
+        return (len(buf) > 3 and
                 buf[0] == 0x77 and
                 buf[1] == 0x4F and
                 buf[2] == 0x46 and
                 buf[3] == 0x46 and
-                buf[4] == 0x00 and
-                buf[5] == 0x01 and
-                buf[6] == 0x00 and
-                buf[7] == 0x00)
+                ((buf[4] == 0x00 and
+                  buf[5] == 0x01 and
+                  buf[6] == 0x00 and
+                  buf[7] == 0x00) or
+                 (buf[4] == 0x4F and
+                  buf[5] == 0x54 and
+                  buf[6] == 0x54 and
+                  buf[7] == 0x4F) or
+                 (buf[4] == 0x74 and
+                  buf[5] == 0x72 and
+                  buf[6] == 0x75 and
+                  buf[7] == 0x65)))
 
 
 class Woff2(Type):
@@ -49,10 +57,18 @@ class Woff2(Type):
                 buf[1] == 0x4F and
                 buf[2] == 0x46 and
                 buf[3] == 0x32 and
-                buf[4] == 0x00 and
-                buf[5] == 0x01 and
-                buf[6] == 0x00 and
-                buf[7] == 0x00)
+                ((buf[4] == 0x00 and
+                  buf[5] == 0x01 and
+                  buf[6] == 0x00 and
+                  buf[7] == 0x00) or
+                 (buf[4] == 0x4F and
+                  buf[5] == 0x54 and
+                  buf[6] == 0x54 and
+                  buf[7] == 0x4F) or
+                 (buf[4] == 0x74 and
+                  buf[5] == 0x72 and
+                  buf[6] == 0x75 and
+                  buf[7] == 0x65)))
 
 
 class Ttf(Type):


### PR DESCRIPTION
Hi, according to the [WOFF File Format 1.0](https://www.w3.org/TR/WOFF/#WOFFHeader) and [WOFF File Format 2.0](https://www.w3.org/TR/WOFF2/#woff20Header) specifications, 

> Although only fonts of type `0x00010000` [...] and `0x4F54544F` [...] are widely supported at present, it is not an error in the WOFF file if the flavor field contains a different value, indicating a WOFF-packaged version of a different sfnt flavor. [...] `0x74727565` has been used for some TrueType-flavored fonts on Mac OS.

In the current state, this library only checks for the TrueType flavor (`0x00010000`), but OpenType flavor (`0x4F54544F`) fonts are common as well, and those are not correctly identified by this library.

As an alternative to https://github.com/h2non/filetype.py/pull/117, if you're not comfortable with allowing arbitrary flavors, I'm proposing implementing support for the three flavors mentioned in the specification itself: `0x00010000` (already present), `0x4F54544F` and `0x74727565`.