### PR TITLE
Support PDF with BOM

### DIFF
--- a/filetype/types/archive.py
+++ b/filetype/types/archive.py
@@ -184,6 +184,13 @@ class Pdf(Type):
         )
 
     def match(self, buf):
+        # Detect BOM and skip first 3 bytes
+        if (len(buf) > 3 and
+            buf[0] == 0xEF and
+            buf[1] == 0xBB and
+            buf[2] == 0xBF):
+            buf = buf[3:]
+
         return (len(buf) > 3 and
                 buf[0] == 0x25 and
                 buf[1] == 0x50 and


### PR DESCRIPTION
We had a few customer-provided PDF files which had a BOM in front of the PDF. While this is not allowed by the PDF spec it seems to be widely accepted by operating systems, applications (Acrobat Reader) and even the `file` command.
We can see the special support for PDF with BOM in `file` here: https://github.com/file/file/blob/master/magic/Magdir/pdf#L28-L34