### PR TITLE
feat: added application/json <--> extension mapping support

### DIFF
--- a/filetype/types/application.py
+++ b/filetype/types/application.py
@@ -20,3 +20,16 @@ class Wasm(Type):
     def match(self, buf):
         return buf[:8] == bytearray([0x00, 0x61, 0x73, 0x6d,
                                      0x01, 0x00, 0x00, 0x00])
+        
+class Json(Type):
+    """Implements the Json image type matcher."""
+    
+    MIME = 'application/json'
+    EXTENSION = 'json'
+    
+    def __init__(self):
+        super(Json, self).__init__(
+            mime=Json.MIME,
+            extension=Json.EXTENSION
+        )
+        


### PR DESCRIPTION
Added support for mapping application/json mime types to the .json file extension.

Still looking for the byte sequence that we can use for application/json detection, but have been unsuccessful so far. If anyone has a source to obtain these or tips for how to find yourself please share.