### PR TITLE
Python 3.10, 3.11 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: ["3.9"]
+        python-version: ["3.11"]
 
     steps:
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: System',
         'Topic :: System :: Filesystems',
         'Topic :: Utilities'],

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,35,36,37,38,39}, lint, test, doc, clean
+envlist = py27, py3{7,5,6,7,8,9,10,11}, lint, test, doc, clean
 skip_missing_interpreters = true
 
 [testenv:test]


### PR DESCRIPTION
fixes #167 
Actually, there are no limitation of the versions. Just info and CI (tox) config.