### PR TITLE
GitHub Actions: Test on Python 3.13 beta

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Upgrade PIP
       run: python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,11 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         python-version: ["3.12", "3.13"]
+        include:
+          - os: macos-latest
+            python-version: '3.13'
+          - os: windows-latest
+            python-version: '3.13'
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,18 +20,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: ["3.11"]
+        python-version: ["3.12", "3.13"]
 
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -56,4 +56,3 @@ jobs:
       with:
         name: coverage_${{ matrix.python-version }}
         path: coverage
-


### PR DESCRIPTION
The Python 3.13 release notes mention `filetype.py` as one of the alternatives for `imghdr` which was removed from the Standard Library so let's ensure that its tests pass on Python 3.13 beta.

https://www.python.org/downloads/release/python-3130b1/

May raise `ModuleNotFoundError: No module named 'imghdr'` because Python 3.13 removes it from the Standard Library.
* https://docs.python.org/3/library/imghdr.html

> imghdr: use the projects [filetype](https://pypi.org/project/filetype/), [puremagic](https://pypi.org/project/puremagic/), or [python-magic](https://pypi.org/project/python-magic/) instead. (Contributed by Victor Stinner in [gh-104773](https://github.com/python/cpython/issues/104773).)

https://docs.python.org/3.13/whatsnew/3.13.html#pep-594-dead-batteries-and-other-module-removals