### PR TITLE
tox.ini: Add Python 3.12 and 3.13 to the tox envlist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         allow-prereleases: true
 
     - name: Upgrade PIP
-      run: python -m pip install --upgrade pip setuptools
+      run: python -m pip install --upgrade pip
 
     - name: Install application with ML
       run: python -m pip install .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         allow-prereleases: true
 
     - name: Upgrade PIP
-      run: python -m pip install --upgrade pip
+      run: python -m pip install --upgrade pip setuptools
 
     - name: Install application with ML
       run: python -m pip install .

--- a/tox.ini
+++ b/tox.ini
@@ -29,9 +29,9 @@ deps =
 commands = flake8 {toxinidir} --extend-exclude tests,docs,build,dist,venv,.venv --extend-ignore=E501
 
 [testenv:doc]
-basepython = python3.10  # pdoc3/pdoc#438
+basepython = python3
 deps =
-     pdoc3
+     pdoc
 commands = pdoc --html --force --output-dir docs filetype
 
 [testenv:clean]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py3{7,5,6,7,8,9,10,11}, lint, test, doc, clean
+envlist = py27, py3{8,9,10,11,12,13}, lint, test, doc, clean
 skip_missing_interpreters = true
 
 [testenv:test]
@@ -29,7 +29,7 @@ deps =
 commands = flake8 {toxinidir} --extend-exclude tests,docs,build,dist,venv,.venv --extend-ignore=E501
 
 [testenv:doc]
-basepython = python3
+basepython = python3.10  # pdoc3/pdoc#438
 deps =
      pdoc3
 commands = pdoc --html --force --output-dir docs filetype

--- a/tox.ini
+++ b/tox.ini
@@ -29,9 +29,9 @@ deps =
 commands = flake8 {toxinidir} --extend-exclude tests,docs,build,dist,venv,.venv --extend-ignore=E501
 
 [testenv:doc]
-basepython = python3
+basepython = python3.10  # pdoc3/pdoc#438
 deps =
-     pdoc
+     pdoc3
 commands = pdoc --html --force --output-dir docs filetype
 
 [testenv:clean]


### PR DESCRIPTION
Let's make our tests green again... ✅ 

Also, see:
* pdoc3/pdoc#438