### PR TITLE
Keep GitHub Actions up to date with GitHub's Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot...
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
 commands = flake8 {toxinidir} --extend-exclude tests,docs,build,dist,venv,.venv --extend-ignore=E501
 
 [testenv:doc]
-basepython = python3
+basepython = python3.10  # pdoc3/pdoc#438
 deps =
      pdoc3
 commands = pdoc --html --force --output-dir docs filetype


### PR DESCRIPTION
Fixed the failing test by lifting a line from
* #176

Fixes software supply chain safety warnings like at the bottom right of
https://github.com/h2non/filetype.py/actions/runs/9054416155

* [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)
* [Configuration options for the dependabot.yml file - package-ecosystem](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)