### PR TITLE
mkv/webm cleanup

### DIFF
--- a/filetype/types/video.py
+++ b/filetype/types/video.py
@@ -67,9 +67,12 @@ class Mkv(Type):
         )
 
     def match(self, buf):
-        contains_ebml_element = buf.startswith(b'\x1A\x45\xDF\xA3')
-        contains_doctype_element = buf.find(b'\x42\x82\x88matroska') > -1
-        return contains_ebml_element and contains_doctype_element
+        if(len(buf) > 5 and
+           buf[0] == 0x1A and
+           buf[1] == 0x45 and
+           buf[2] == 0xDF and
+           buf[3] == 0xA3):
+            return buf[5:64].find(b"matroska") > -1
 
 
 class Webm(Type):
@@ -86,9 +89,12 @@ class Webm(Type):
         )
 
     def match(self, buf):
-        contains_ebml_element = buf.startswith(b'\x1A\x45\xDF\xA3')
-        contains_doctype_element = buf.find(b'\x42\x82\x84webm') > -1
-        return contains_ebml_element and contains_doctype_element
+        if(len(buf) > 5 and
+           buf[0] == 0x1A and
+           buf[1] == 0x45 and
+           buf[2] == 0xDF and
+           buf[3] == 0xA3):
+            return buf[5:64].find(b"webm") > -1
 
 
 class Mov(IsoBmff):


### PR DESCRIPTION
check EBML header first, then do `find` and limit `find` range to 64 bytes (i dont think EBML header can be that large)

also this pr fixes webm detection that created with GStreamer Matroska muxer / GStreamer matroskamux:
DocType have `webm\x00` so DocType size is different, ex. `0x42, 0x82, 0x85, 0x77, 0x65, 0x62, 0x6D, 0x00`