### PR TITLE
Fix JXL ISOBMFF format

### DIFF
--- a/filetype/types/image.py
+++ b/filetype/types/image.py
@@ -68,13 +68,13 @@ class Jxl(Type):
              buf[0] == 0x00 and
              buf[1] == 0x00 and
              buf[2] == 0x00 and
-             buf[3] == 0x00 and
-             buf[4] == 0x0C and
-             buf[5] == 0x4A and
-             buf[6] == 0x58 and
-             buf[7] == 0x4C and
-             buf[8] == 0x20 and
-             buf[9] == 0x0D and
+             buf[3] == 0x0C and
+             buf[4] == 0x4A and
+             buf[5] == 0x58 and
+             buf[6] == 0x4C and
+             buf[7] == 0x20 and
+             buf[8] == 0x0D and
+             buf[9] == 0x0A and
              buf[10] == 0x87 and
              buf[11] == 0x0A)
         )


### PR DESCRIPTION
From the spec: https://github.com/libjxl/libjxl/blob/main/doc/format_overview.md#file-format

> An ISOBMFF-based container. This is a box-based container that includes a JPEG XL codestream box (jxlc), and can optionally include other boxes with additional information, such as Exif metadata. In this case, the file starts with the bytes 0x0000000C 4A584C20 0D0A870A.

```
00 00 00 0C 4A 58 4C 20 0D 0A 87 0A
0  1  2  3  4  5  6  7  8  9  10 11
```