### PR TITLE
Preserve order of types in each format

### DIFF
--- a/filetype/types/__init__.py
+++ b/filetype/types/__init__.py
@@ -17,7 +17,6 @@ IMAGE = (
     image.Xcf(),
     image.Jpeg(),
     image.Jpx(),
-    image.Jxl(),
     image.Apng(),
     image.Png(),
     image.Gif(),
@@ -33,6 +32,7 @@ IMAGE = (
     image.Avif(),
     image.Qoi(),
     image.Dds(),
+    image.Jxl(),
 )
 
 # Supported video types


### PR DESCRIPTION
Some software depends on order of types inside each format when assign ID to them. For example using `enumerate` or similar feature. This commit preserve order of types by adding new ones to the end.